### PR TITLE
Prevent duplicate FITID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+ofx
+input
+.DS_Store

--- a/ing2ofx.py
+++ b/ing2ofx.py
@@ -49,7 +49,6 @@ class CsvFile:
 
         # Keep track of used IDs to prevent double IDs
         idslist = []
-        idcount = 1
 
         with open(args.csvfile, 'rb') as csvfile:
             # Open the csvfile as a Dictreader
@@ -119,16 +118,18 @@ class CsvFile:
                     trnamt.replace(",", "").replace("-", "").replace(".", "")
 
                 # Check if we already used a certain ID
-                while fitid in idslist:
+                idcount = 0
+                uniqueid = fitid
+                while uniqueid in idslist:
                   idcount = idcount + 1
-                  fitid = fitid + str(idcount)
+                  uniqueid = fitid + str(idcount)
 
                 # Append ID to list with IDs
-                idslist.append(fitid)
+                idslist.append(uniqueid)
 
                 self.transactions.append(
                     {'account': account, 'trntype': trntype, 'dtposted': dtposted,
-                     'trnamt': trnamt, 'fitid': fitid, 'name': name, 'accountto': accountto,
+                     'trnamt': trnamt, 'fitid': uniqueid, 'name': name, 'accountto': accountto,
                      'memo': memo})
 
 


### PR DESCRIPTION
When transactions with the same amount occured on the same day a duplicate FITID was created. This gave issues when loading the data. Fixed the issue by appending time and accountto to the FITID. In some special cases this could still result in a duplicate FITID (sometimes time is not specified and accountto could be the same). This is fixed by checking whether the ID already exists and if so add an incremental number to ensure uniqueness.
